### PR TITLE
Fix return type for vec_permxor

### DIFF
--- a/Intrinsics_Reference/ch_vec_reference.xml
+++ b/Intrinsics_Reference/ch_vec_reference.xml
@@ -25149,7 +25149,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
             </row>
             <row>
               <entry align="center" valign="middle">
-                <para>vector unsigned char</para>
+                <para>vector signed char</para>
               </entry>
               <entry align="center" valign="middle">
                 <para>vector signed char</para>


### PR DESCRIPTION
The return type for `vec_permxor` which takes `vector signed char`
as inputs should also be `vector signed char`.

Fixes #38.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>