### PR TITLE
Add examples for vec_double{e,h,l,o}

### DIFF
--- a/Intrinsics_Reference/ch_vec_reference.xml
+++ b/Intrinsics_Reference/ch_vec_reference.xml
@@ -11627,6 +11627,51 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
       the converted values of elements 0 and 2 of <emphasis
       role="bold">a</emphasis>.
       </para>
+      <para>An example where <emphasis role="bold">a</emphasis>
+      is of type vector signed int follows:
+      <informaltable frame="all">
+      <tgroup cols="5">
+          <colspec colname="c0" colwidth="20*" />
+          <colspec colname="c1L" colwidth="10*" />
+          <colspec colname="c1R" colwidth="10*" />
+          <colspec colname="c2L" colwidth="10*" />
+          <colspec colname="c2R" colwidth="10*" />
+          <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
+          <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <tbody>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">a</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00000001</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para><emphasis>(ignored)</emphasis></para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>FFFFFFFF</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para><emphasis>(ignored)</emphasis></para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">r</emphasis> </para>
+              </entry>
+              <entry align="center" spanname="c1" valign="middle">
+                <para>1.0</para>
+              </entry>
+              <entry align="center" spanname="c2" valign="middle">
+                <para>-1.0</para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </informaltable>
+      </para>
+
       <para><emphasis role="bold">Endian considerations:</emphasis>
       Differences in element numbering require different implementations
       for big- and little-endian code generation.
@@ -11779,6 +11824,51 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
       the converted values of elements 0 and 1 of <emphasis
       role="bold">a</emphasis>.
       </para>
+      <para>An example where <emphasis role="bold">a</emphasis>
+      is of type vector signed int follows:
+      <informaltable frame="all">
+      <tgroup cols="5">
+          <colspec colname="c0" colwidth="20*" />
+          <colspec colname="c1L" colwidth="10*" />
+          <colspec colname="c1R" colwidth="10*" />
+          <colspec colname="c2L" colwidth="10*" />
+          <colspec colname="c2R" colwidth="10*" />
+          <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
+          <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <tbody>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">a</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00000001</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>FFFFFFFF</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para><emphasis>(ignored)</emphasis></para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para><emphasis>(ignored)</emphasis></para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">r</emphasis> </para>
+              </entry>
+              <entry align="center" spanname="c1" valign="middle">
+                <para>1.0</para>
+              </entry>
+              <entry align="center" spanname="c2" valign="middle">
+                <para>-1.0</para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </informaltable>
+      </para>
+
       <para><emphasis role="bold">Endian considerations:</emphasis>
       Differences in element numbering require different implementations
       for big- and little-endian code generation.
@@ -11937,6 +12027,51 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
       the converted values of elements 2 and 3 of <emphasis
       role="bold">a</emphasis>.
       </para>
+      <para>An example where <emphasis role="bold">a</emphasis>
+      is of type vector signed int follows:
+      <informaltable frame="all">
+      <tgroup cols="5">
+          <colspec colname="c0" colwidth="20*" />
+          <colspec colname="c1L" colwidth="10*" />
+          <colspec colname="c1R" colwidth="10*" />
+          <colspec colname="c2L" colwidth="10*" />
+          <colspec colname="c2R" colwidth="10*" />
+          <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
+          <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <tbody>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">a</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para><emphasis>(ignored)</emphasis></para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para><emphasis>(ignored)</emphasis></para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00000001</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>FFFFFFFF</para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">r</emphasis> </para>
+              </entry>
+              <entry align="center" spanname="c1" valign="middle">
+                <para>1.0</para>
+              </entry>
+              <entry align="center" spanname="c2" valign="middle">
+                <para>-1.0</para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </informaltable>
+      </para>
+
       <para><emphasis role="bold">Endian considerations:</emphasis>
       Differences in element numbering require different implementations
       for big- and little-endian code generation.
@@ -12095,6 +12230,51 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
       the converted values of elements 1 and 3 of <emphasis
       role="bold">a</emphasis>.
       </para>
+      <para>An example where <emphasis role="bold">a</emphasis>
+      is of type vector signed int follows:
+      <informaltable frame="all">
+      <tgroup cols="5">
+          <colspec colname="c0" colwidth="20*" />
+          <colspec colname="c1L" colwidth="10*" />
+          <colspec colname="c1R" colwidth="10*" />
+          <colspec colname="c2L" colwidth="10*" />
+          <colspec colname="c2R" colwidth="10*" />
+          <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
+          <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <tbody>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">a</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para><emphasis>(ignored)</emphasis></para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00000001</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para><emphasis>(ignored)</emphasis></para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>FFFFFFFF</para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">r</emphasis> </para>
+              </entry>
+              <entry align="center" spanname="c1" valign="middle">
+                <para>1.0</para>
+              </entry>
+              <entry align="center" spanname="c2" valign="middle">
+                <para>-1.0</para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </informaltable>
+      </para>
+
       <para><emphasis role="bold">Endian considerations:</emphasis>
       Differences in element numbering require different implementations
       for big- and little-endian code generation.


### PR DESCRIPTION
* PDF:
  * `vec_doublee`:
   > ![Screenshot from 2020-05-05 05-27-18](https://user-images.githubusercontent.com/12301795/81057190-90dc9a00-8e91-11ea-88f6-a32485c40016.png)
  * `vec_doubleh`:
  > ![Screenshot from 2020-05-05 05-28-02](https://user-images.githubusercontent.com/12301795/81057212-9afe9880-8e91-11ea-9b9a-2853b3ac9eeb.png)
  * `vec_doublel`:
  > ![Screenshot from 2020-05-05 05-28-20](https://user-images.githubusercontent.com/12301795/81057230-a18d1000-8e91-11ea-85c5-86e84cf66ebd.png)
  * `vec_doubleo`:
  > ![Screenshot from 2020-05-05 05-28-39](https://user-images.githubusercontent.com/12301795/81057238-a8b41e00-8e91-11ea-9df4-92642f37df0f.png)
* web:
  * `vec_doublee`:
  > ![Screenshot from 2020-05-05 05-29-07](https://user-images.githubusercontent.com/12301795/81057251-aea9ff00-8e91-11ea-8247-9e2e84d03aae.png)
  * `vec_doubleh`:
  > ![Screenshot from 2020-05-05 05-29-24](https://user-images.githubusercontent.com/12301795/81057262-b2d61c80-8e91-11ea-9399-63b2a426365c.png)
  * `vec_doublel`:
  > ![Screenshot from 2020-05-05 05-29-38](https://user-images.githubusercontent.com/12301795/81057270-b669a380-8e91-11ea-89ff-5d59ca0e4fb1.png)
  * `vec_doubleo`:
  > ![Screenshot from 2020-05-05 05-30-05](https://user-images.githubusercontent.com/12301795/81057275-b9649400-8e91-11ea-9bef-1b0d1c878c53.png)







Fixes #16.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>