### PR TITLE
Add examples for vec_extract_fp32_from_short{h,l}

### DIFF
--- a/Intrinsics_Reference/ch_vec_reference.xml
+++ b/Intrinsics_Reference/ch_vec_reference.xml
@@ -13208,6 +13208,130 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
       interpreted as 16-bit floating-point numbers in IEEE format, and
       extended to single-precision format, returning a vector with four
       single-precision IEEE numbers.</para>
+      <para>An example follows:
+      <informaltable frame="all">
+      <tgroup cols="9">
+          <colspec colname="c0" colwidth="20*" />
+          <colspec colname="c1" colwidth="10*" />
+          <colspec colname="c2" colwidth="10*" />
+          <colspec colname="c3" colwidth="10*" />
+          <colspec colname="c4" colwidth="10*" />
+          <colspec colname="c5" colwidth="10*" />
+          <colspec colname="c6" colwidth="10*" />
+          <colspec colname="c7" colwidth="10*" />
+          <colspec colname="c8" colwidth="10*" />
+          <spanspec spanname="w1" namest="c1" nameend="c2"/>
+          <spanspec spanname="w2" namest="c3" nameend="c4"/>
+          <spanspec spanname="w3" namest="c5" nameend="c6"/>
+          <spanspec spanname="w4" namest="c7" nameend="c8"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>halfword index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>4</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>5</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>6</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>7</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry spanname="w1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="w2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry spanname="w3" align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry spanname="w4" align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">a</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>3800</para>
+                <para>(0.5)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>4200</para>
+                <para>(3.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>4700</para>
+                <para>(7.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>4B80</para>
+                <para>(15.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>4FC0</para>
+                <para>(31.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>53E0</para>
+                <para>(63.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>57F0</para>
+                <para>(127.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>5BF8</para>
+                <para>(255.0)</para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">r</emphasis> </para>
+              </entry>
+              <entry spanname="w1" align="center" valign="middle">
+                <para>0.5</para>
+              </entry>
+              <entry spanname="w2" align="center" valign="middle">
+                <para>3.0</para>
+              </entry>
+              <entry spanname="w3" align="center" valign="middle">
+                <para>7.0</para>
+              </entry>
+              <entry spanname="w4" align="center" valign="middle">
+                <para>15.0</para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </informaltable>
+      </para>
+
       <para><emphasis role="bold">Endian considerations:</emphasis>
       The element numbering within a register is left-to-right for big-endian
       targets, and right-to-left for little-endian targets.
@@ -13309,6 +13433,130 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
       interpreted as 16-bit floating-point numbers in IEEE format, and
       extended to single-precision format, returning a vector with four
       single-precision IEEE numbers.</para>
+      <para>An example follows:
+      <informaltable frame="all">
+      <tgroup cols="9">
+          <colspec colname="c0" colwidth="20*" />
+          <colspec colname="c1" colwidth="10*" />
+          <colspec colname="c2" colwidth="10*" />
+          <colspec colname="c3" colwidth="10*" />
+          <colspec colname="c4" colwidth="10*" />
+          <colspec colname="c5" colwidth="10*" />
+          <colspec colname="c6" colwidth="10*" />
+          <colspec colname="c7" colwidth="10*" />
+          <colspec colname="c8" colwidth="10*" />
+          <spanspec spanname="w1" namest="c1" nameend="c2"/>
+          <spanspec spanname="w2" namest="c3" nameend="c4"/>
+          <spanspec spanname="w3" namest="c5" nameend="c6"/>
+          <spanspec spanname="w4" namest="c7" nameend="c8"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>halfword index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>4</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>5</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>6</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>7</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry spanname="w1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="w2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry spanname="w3" align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry spanname="w4" align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">a</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>3800</para>
+                <para>(0.5)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>4200</para>
+                <para>(3.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>4700</para>
+                <para>(7.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>4B80</para>
+                <para>(15.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>4FC0</para>
+                <para>(31.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>53E0</para>
+                <para>(63.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>57F0</para>
+                <para>(127.0)</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>5BF8</para>
+                <para>(255.0)</para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">r</emphasis> </para>
+              </entry>
+              <entry spanname="w1" align="center" valign="middle">
+                <para>31.0</para>
+              </entry>
+              <entry spanname="w2" align="center" valign="middle">
+                <para>63.0</para>
+              </entry>
+              <entry spanname="w3" align="center" valign="middle">
+                <para>127.0</para>
+              </entry>
+              <entry spanname="w4" align="center" valign="middle">
+                <para>255.0</para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </informaltable>
+      </para>
+
       <para><emphasis role="bold">Endian considerations:</emphasis>
       The element numbering within a register is left-to-right for big-endian
       targets, and right-to-left for little-endian targets.


### PR DESCRIPTION
Also added table headers to more clearly indicate element ordering.

Fixes #17.

* PDF:
  * `vec_extract_fp32_from_shorth`:
  > ![Screenshot from 2020-05-05 12-32-41](https://user-images.githubusercontent.com/12301795/81096965-ce124d80-8ecc-11ea-8b5d-53af57775926.png)
  * `vec_extract_fp32_from_shortl`:
  > ![Screenshot from 2020-05-05 12-33-04](https://user-images.githubusercontent.com/12301795/81096979-d1a5d480-8ecc-11ea-8d6a-897a759e316d.png)
* web:
  * `vec_extract_fp32_from_shorth`:
  > ![Screenshot from 2020-05-05 12-33-56](https://user-images.githubusercontent.com/12301795/81096987-d4a0c500-8ecc-11ea-8455-471a0dcb08ec.png)
  * `vec_extract_fp32_from_shortl`:
  > ![Screenshot from 2020-05-05 12-34-16](https://user-images.githubusercontent.com/12301795/81096997-d79bb580-8ecc-11ea-9d17-cf03bbf8d6d9.png)

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>