### PR TITLE
Add headers for new examples

### DIFF
--- a/Intrinsics_Reference/ch_vec_reference.xml
+++ b/Intrinsics_Reference/ch_vec_reference.xml
@@ -11638,6 +11638,36 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c2R" colwidth="10*" />
           <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
           <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>doubleword index</emphasis> </para>
+              </entry>
+              <entry spanname="c1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="c2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -11835,6 +11865,36 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c2R" colwidth="10*" />
           <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
           <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>doubleword index</emphasis> </para>
+              </entry>
+              <entry spanname="c1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="c2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -12038,6 +12098,36 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c2R" colwidth="10*" />
           <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
           <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>doubleword index</emphasis> </para>
+              </entry>
+              <entry spanname="c1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="c2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -12241,6 +12331,36 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c2R" colwidth="10*" />
           <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
           <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>doubleword index</emphasis> </para>
+              </entry>
+              <entry spanname="c1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="c2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -25074,6 +25194,61 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <spanspec spanname="c14" namest="c14L" nameend="c14R"/>
           <spanspec spanname="c15" namest="c15L" nameend="c15R"/>
           <spanspec spanname="c16" namest="c16L" nameend="c16R"/>
+          <thead>
+            <row>
+              <entry spanname="c0" align="center" valign="middle">
+                <para> <emphasis>byte index</emphasis> </para>
+              </entry>
+              <entry spanname="c1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="c2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry spanname="c3" align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry spanname="c4" align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+              <entry spanname="c5" align="center" valign="middle">
+                <para> <emphasis>4</emphasis> </para>
+              </entry>
+              <entry spanname="c6" align="center" valign="middle">
+                <para> <emphasis>5</emphasis> </para>
+              </entry>
+              <entry spanname="c7" align="center" valign="middle">
+                <para> <emphasis>6</emphasis> </para>
+              </entry>
+              <entry spanname="c8" align="center" valign="middle">
+                <para> <emphasis>7</emphasis> </para>
+              </entry>
+              <entry spanname="c9" align="center" valign="middle">
+                <para> <emphasis>8</emphasis> </para>
+              </entry>
+              <entry spanname="c10" align="center" valign="middle">
+                <para> <emphasis>9</emphasis> </para>
+              </entry>
+              <entry spanname="c11" align="center" valign="middle">
+                <para> <emphasis>10</emphasis> </para>
+              </entry>
+              <entry spanname="c12" align="center" valign="middle">
+                <para> <emphasis>11</emphasis> </para>
+              </entry>
+              <entry spanname="c13" align="center" valign="middle">
+                <para> <emphasis>12</emphasis> </para>
+              </entry>
+              <entry spanname="c14" align="center" valign="middle">
+                <para> <emphasis>13</emphasis> </para>
+              </entry>
+              <entry spanname="c15" align="center" valign="middle">
+                <para> <emphasis>14</emphasis> </para>
+              </entry>
+              <entry spanname="c16" align="center" valign="middle">
+                <para> <emphasis>15</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" spanname="c0" valign="middle">
@@ -25670,6 +25845,36 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c2R" colwidth="10*" />
           <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
           <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>doubleword index</emphasis> </para>
+              </entry>
+              <entry spanname="c1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="c2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -30541,6 +30746,61 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c14" colwidth="10*" />
           <colspec colname="c15" colwidth="10*" />
           <colspec colname="c16" colwidth="10*" />
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>byte index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>4</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>5</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>6</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>7</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>8</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>9</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>10</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>11</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>12</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>13</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>14</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>15</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -32959,6 +33219,61 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c14" colwidth="10*" />
           <colspec colname="c15" colwidth="10*" />
           <colspec colname="c16" colwidth="10*" />
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>byte index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>4</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>5</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>6</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>7</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>8</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>9</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>10</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>11</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>12</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>13</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>14</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>15</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -35600,6 +35915,25 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c2" colwidth="10*" />
           <colspec colname="c3" colwidth="10*" />
           <colspec colname="c4" colwidth="10*" />
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -35833,6 +36167,78 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <spanspec spanname="w2" namest="c5" nameend="c8"/>
           <spanspec spanname="w3" namest="c9" nameend="c12"/>
           <spanspec spanname="w4" namest="c13" nameend="c16"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry spanname="w1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="w2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry spanname="w3" align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry spanname="w4" align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>byte index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>4</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>5</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>6</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>7</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>8</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>9</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>10</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>11</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>12</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>13</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>14</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>15</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -35961,6 +36367,54 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <spanspec spanname="w2" namest="c3" nameend="c4"/>
           <spanspec spanname="w3" namest="c5" nameend="c6"/>
           <spanspec spanname="w4" namest="c7" nameend="c8"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry spanname="w1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="w2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry spanname="w3" align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry spanname="w4" align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>halfword index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>4</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>5</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>6</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>7</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -36176,6 +36630,25 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c3" colwidth="10*" />
           <colspec colname="c4" colwidth="10*" />
           <colspec colname="c5" colwidth="10*" />
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -37359,6 +37832,36 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c2R" colwidth="10*" />
           <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
           <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>doubleword index</emphasis> </para>
+              </entry>
+              <entry spanname="c1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="c2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">
@@ -37496,6 +37999,36 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
           <colspec colname="c2R" colwidth="10*" />
           <spanspec spanname="c1" namest="c1L" nameend="c1R"/>
           <spanspec spanname="c2" namest="c2L" nameend="c2R"/>
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>doubleword index</emphasis> </para>
+              </entry>
+              <entry spanname="c1" align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry spanname="c2" align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>word index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
           <tbody>
             <row>
               <entry align="center" valign="middle">


### PR DESCRIPTION
In the absence of sufficient context, the new examples added to:
- vec_double{e,h,l,o}
- vec_permxor
- vec_pmsum_be
- vec_slv
- vec_srv
- vec_sum2s
- vec_sum4s
- vec_sums
- vec_unsigned{e,o}
may appear to be strictly big-endian.

Add headers to these examples showing the element indicies,
which hopefully provides sufficient context.

Fixes #44.

* `vec_doublee`
![Screenshot from 2020-05-08 05-33-42](https://user-images.githubusercontent.com/12301795/81399048-ff1e9800-90ef-11ea-9975-4d60447a1c84.png)
![Screenshot from 2020-05-08 05-34-19](https://user-images.githubusercontent.com/12301795/81399049-ffb72e80-90ef-11ea-8357-a9f5a57b4015.png)
* `vec_doubleh`
![Screenshot from 2020-05-08 05-34-50](https://user-images.githubusercontent.com/12301795/81399050-ffb72e80-90ef-11ea-8b0a-62a401e1f989.png)
![Screenshot from 2020-05-08 05-35-08](https://user-images.githubusercontent.com/12301795/81399051-ffb72e80-90ef-11ea-8bb8-8cb490a37e6d.png)
* `vec_doublel`
![Screenshot from 2020-05-08 05-35-28](https://user-images.githubusercontent.com/12301795/81399052-004fc500-90f0-11ea-8142-7dcad93535c7.png)
![Screenshot from 2020-05-08 05-35-54](https://user-images.githubusercontent.com/12301795/81399053-004fc500-90f0-11ea-9f72-9200641c8764.png)
* `vec_doubleo`
![Screenshot from 2020-05-08 05-36-21](https://user-images.githubusercontent.com/12301795/81399056-004fc500-90f0-11ea-9c9a-dafceccb632f.png)
![Screenshot from 2020-05-08 05-36-36](https://user-images.githubusercontent.com/12301795/81399057-00e85b80-90f0-11ea-82b1-5e1d0f41d2d6.png)
* `vec_permxor`
![Screenshot from 2020-05-08 05-37-09](https://user-images.githubusercontent.com/12301795/81399058-00e85b80-90f0-11ea-8dfe-ce993fba59b1.png)
![Screenshot from 2020-05-08 05-37-41](https://user-images.githubusercontent.com/12301795/81399059-00e85b80-90f0-11ea-9ab6-fc5f6a454633.png)
* `vec_pmsum_be`
![Screenshot from 2020-05-08 05-38-03](https://user-images.githubusercontent.com/12301795/81399060-0180f200-90f0-11ea-8c17-06c1b9ae3832.png)
![Screenshot from 2020-05-08 05-38-30](https://user-images.githubusercontent.com/12301795/81399061-0180f200-90f0-11ea-9efe-961fceb3fb61.png)
* `vec_slv`
![Screenshot from 2020-05-08 05-39-10](https://user-images.githubusercontent.com/12301795/81399065-02198880-90f0-11ea-9c2f-e619f57c7711.png)
![Screenshot from 2020-05-08 05-39-42](https://user-images.githubusercontent.com/12301795/81399067-02198880-90f0-11ea-94e4-52511620a5b6.png)
* `vec_srv`
![Screenshot from 2020-05-08 05-40-25](https://user-images.githubusercontent.com/12301795/81399068-02198880-90f0-11ea-931a-f3aa1d6c0ea9.png)
![Screenshot from 2020-05-08 05-40-42](https://user-images.githubusercontent.com/12301795/81399072-02b21f00-90f0-11ea-8106-11f1d2cf6611.png)
* `vec_sum2s`
![Screenshot from 2020-05-08 05-41-11](https://user-images.githubusercontent.com/12301795/81399073-02b21f00-90f0-11ea-93e5-03c2b2e8d67a.png)
![Screenshot from 2020-05-08 05-41-48](https://user-images.githubusercontent.com/12301795/81399074-02b21f00-90f0-11ea-8441-8537065ab1b9.png)
* `vec_sum4s`
![Screenshot from 2020-05-08 05-42-11](https://user-images.githubusercontent.com/12301795/81399076-02b21f00-90f0-11ea-85ff-11a559bb4109.png)
![Screenshot from 2020-05-08 05-42-49](https://user-images.githubusercontent.com/12301795/81399078-034ab580-90f0-11ea-96c3-49156615b1f7.png)
* `vec_sums`
![Screenshot from 2020-05-08 05-43-21](https://user-images.githubusercontent.com/12301795/81399081-034ab580-90f0-11ea-9748-ae279154d6e2.png)
![Screenshot from 2020-05-08 05-44-26](https://user-images.githubusercontent.com/12301795/81399082-034ab580-90f0-11ea-95b1-ddeb0826732c.png)
* `vec_unsignede`
![Screenshot from 2020-05-08 05-45-02](https://user-images.githubusercontent.com/12301795/81399087-03e34c00-90f0-11ea-8e88-07774ef4dade.png)
![Screenshot from 2020-05-08 05-45-22](https://user-images.githubusercontent.com/12301795/81399088-03e34c00-90f0-11ea-9597-e944e4f6a9d8.png)
* `vec_unsignedo`
![Screenshot from 2020-05-08 05-45-38](https://user-images.githubusercontent.com/12301795/81399089-03e34c00-90f0-11ea-99f6-7179d5489f66.png)
![Screenshot from 2020-05-08 05-58-03](https://user-images.githubusercontent.com/12301795/81399667-02feea00-90f1-11ea-9342-1c4fb6c4fbfe.png)


Signed-off-by: Paul A. Clarke <pc@us.ibm.com>