### PR TITLE
Add examples for count leading/trailing zeros

### DIFF
--- a/Intrinsics_Reference/ch_vec_reference.xml
+++ b/Intrinsics_Reference/ch_vec_reference.xml
@@ -10891,6 +10891,193 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
       set to the number of leading zeros of the corresponding element
       of <emphasis role="bold">a</emphasis>.
       </para>
+      <para>An example follows:
+      <informaltable frame="all">
+      <tgroup cols="17">
+          <colspec colname="c0" colwidth="50*" />
+          <colspec colname="c1" colwidth="10*" />
+          <colspec colname="c2" colwidth="10*" />
+          <colspec colname="c3" colwidth="10*" />
+          <colspec colname="c4" colwidth="10*" />
+          <colspec colname="c5" colwidth="10*" />
+          <colspec colname="c6" colwidth="10*" />
+          <colspec colname="c7" colwidth="10*" />
+          <colspec colname="c8" colwidth="10*" />
+          <colspec colname="c9" colwidth="10*" />
+          <colspec colname="c10" colwidth="10*" />
+          <colspec colname="c11" colwidth="10*" />
+          <colspec colname="c12" colwidth="10*" />
+          <colspec colname="c13" colwidth="10*" />
+          <colspec colname="c14" colwidth="10*" />
+          <colspec colname="c15" colwidth="10*" />
+          <colspec colname="c16" colwidth="10*" />
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>byte index</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>4</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>5</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>6</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>7</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>8</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>9</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>10</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>11</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>12</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>13</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>14</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>15</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">a</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>10</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>20</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>30</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>48</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>58</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>64</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>74</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>82</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>92</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>A1</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>B1</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>C0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>D0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>E0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>F0</para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">r</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>08</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>03</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>02</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>02</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>01</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>01</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>01</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>01</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00</para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </informaltable>
+      </para>
+
       <para><emphasis role="bold">Endian considerations:</emphasis>
       None.
       </para>
@@ -11098,8 +11285,206 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
       element) of <emphasis role="bold">a</emphasis> that have a
       least-significant bit of zero.
       </para>
+      <para>An example follows:
+      <informaltable frame="all">
+      <tgroup cols="17">
+          <colspec colname="c0" colwidth="50*" />
+          <colspec colname="c1" colwidth="10*" />
+          <colspec colname="c2" colwidth="10*" />
+          <colspec colname="c3" colwidth="10*" />
+          <colspec colname="c4" colwidth="10*" />
+          <colspec colname="c5" colwidth="10*" />
+          <colspec colname="c6" colwidth="10*" />
+          <colspec colname="c7" colwidth="10*" />
+          <colspec colname="c8" colwidth="10*" />
+          <colspec colname="c9" colwidth="10*" />
+          <colspec colname="c10" colwidth="10*" />
+          <colspec colname="c11" colwidth="10*" />
+          <colspec colname="c12" colwidth="10*" />
+          <colspec colname="c13" colwidth="10*" />
+          <colspec colname="c14" colwidth="10*" />
+          <colspec colname="c15" colwidth="10*" />
+          <colspec colname="c16" colwidth="10*" />
+          <spanspec spanname="result" namest="c1" nameend="c16" />
+           <thead>
+             <row>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>byte index</emphasis> n </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>0</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>1</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>2</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>3</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>4</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>5</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>6</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>7</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>8</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>9</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>10</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>11</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>12</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>13</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>14</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>15</emphasis> </para>
+               </entry>
+             </row>
+           </thead>
+           <tbody>
+             <row>
+               <entry align="center" valign="middle">
+                 <para> <emphasis role="bold">a</emphasis> </para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>00</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>10</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>20</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>30</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>48</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>58</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>64</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>74</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>82</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>92</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>A1</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>B1</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>C0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>D0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>E0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>F0</para>
+               </entry>
+             </row>
+             <row>
+               <entry align="center" valign="middle">
+                 <para> <emphasis>least-significant bit of</emphasis> <emphasis role="bold">a</emphasis><subscript>n</subscript></para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>1</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>1</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+               <entry align="center" valign="middle">
+                 <para>0</para>
+               </entry>
+             </row>
+             <row>
+               <entry align="center" valign="middle">
+                 <para> <emphasis role="bold">r</emphasis> </para>
+               </entry>
+               <entry spanname="result" align="center" valign="middle">
+                 <para>0x0A (10)</para>
+               </entry>
+             </row>
+           </tbody>
+         </tgroup>
+       </informaltable>
+       </para>
+
       <para><emphasis role="bold">Endian considerations:</emphasis>
-      None.
+      The element numbering within a register is left-to-right for
+      big-endian targets, and right-to-left for little-endian
+      targets.
       </para>
       
       <indexterm>
@@ -11109,11 +11494,12 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
 
       <table frame="all">
 	<title>Supported type signatures for vec_cntlz_lsbb</title>
-	<tgroup cols="4">
+	<tgroup cols="5">
           <colspec colname="c1" colwidth="20*" />
           <colspec colname="c2" colwidth="20*" />
           <colspec colname="c3" colwidth="20*" />
           <colspec colname="c4" colwidth="20*" />
+          <colspec colname="c5" colwidth="20*" />
           <thead>
             <row>
               <entry align="center" valign="middle">
@@ -11128,7 +11514,12 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
               </entry>
               <entry align="center" valign="middle">
 		<para>
-                  <emphasis role="bold">Example Implementation</emphasis>
+                  <emphasis role="bold">Example BE Implementation</emphasis>
+		</para>
+              </entry>
+              <entry align="center" valign="middle">
+		<para>
+                  <emphasis role="bold">Example LE Implementation</emphasis>
 		</para>
               </entry>
               <entry align="center" valign="middle">
@@ -11151,6 +11542,11 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
    vclzlsbb  r,a
 		</programlisting>
               </entry>
+              <entry>
+		<programlisting>
+   vctzlsbb  r,a
+		</programlisting>
+              </entry>
               <entry align="center" valign="middle">
 		<para>ISA 3.0 or later</para>
 	      </entry>
@@ -11165,6 +11561,11 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
               <entry>
 		<programlisting>
    vclzlsbb  r,a
+		</programlisting>
+              </entry>
+              <entry>
+		<programlisting>
+   vctzlsbb  r,a
 		</programlisting>
               </entry>
               <entry align="center" valign="middle">
@@ -11401,8 +11802,206 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
       element) of <emphasis role="bold">a</emphasis> that have a
       least-significant bit of zero.
       </para>
+      <para>An example follows:
+      <informaltable frame="all">
+      <tgroup cols="17">
+          <colspec colname="c0" colwidth="50*" />
+          <colspec colname="c1" colwidth="10*" />
+          <colspec colname="c2" colwidth="10*" />
+          <colspec colname="c3" colwidth="10*" />
+          <colspec colname="c4" colwidth="10*" />
+          <colspec colname="c5" colwidth="10*" />
+          <colspec colname="c6" colwidth="10*" />
+          <colspec colname="c7" colwidth="10*" />
+          <colspec colname="c8" colwidth="10*" />
+          <colspec colname="c9" colwidth="10*" />
+          <colspec colname="c10" colwidth="10*" />
+          <colspec colname="c11" colwidth="10*" />
+          <colspec colname="c12" colwidth="10*" />
+          <colspec colname="c13" colwidth="10*" />
+          <colspec colname="c14" colwidth="10*" />
+          <colspec colname="c15" colwidth="10*" />
+          <colspec colname="c16" colwidth="10*" />
+          <spanspec spanname="result" namest="c1" nameend="c16" />
+          <thead>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>byte index</emphasis> n </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>0</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>1</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>2</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>3</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>4</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>5</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>6</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>7</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>8</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>9</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>10</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>11</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>12</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>13</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>14</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para> <emphasis>15</emphasis> </para>
+              </entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">a</emphasis> </para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>00</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>10</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>20</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>30</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>48</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>58</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>64</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>74</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>82</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>92</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>A1</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>B1</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>C0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>D0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>E0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>F0</para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis>least-significant bit of</emphasis> <emphasis role="bold">a</emphasis><subscript>n</subscript></para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>1</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>1</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+              <entry align="center" valign="middle">
+                <para>0</para>
+              </entry>
+            </row>
+            <row>
+              <entry align="center" valign="middle">
+                <para> <emphasis role="bold">r</emphasis> </para>
+              </entry>
+              <entry spanname="result" align="center" valign="middle">
+                <para>0x04 (4)</para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </informaltable>
+      </para>
+
       <para><emphasis role="bold">Endian considerations:</emphasis>
-      None.
+      The element numbering within a register is left-to-right for
+      big-endian targets, and right-to-left for little-endian
+      targets.
       </para>
       
       <indexterm>
@@ -11412,11 +12011,12 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
 
       <table frame="all">
 	<title>Supported type signatures for vec_cnttz_lsbb</title>
-	<tgroup cols="4">
+	<tgroup cols="5">
           <colspec colname="c1" colwidth="20*" />
           <colspec colname="c2" colwidth="20*" />
           <colspec colname="c3" colwidth="20*" />
           <colspec colname="c4" colwidth="20*" />
+          <colspec colname="c5" colwidth="20*" />
           <thead>
             <row>
               <entry align="center" valign="middle">
@@ -11431,7 +12031,12 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
               </entry>
               <entry align="center" valign="middle">
 		<para>
-                  <emphasis role="bold">Example Implementation</emphasis>
+                  <emphasis role="bold">Example BE Implementation</emphasis>
+		</para>
+              </entry>
+              <entry align="center" valign="middle">
+		<para>
+                  <emphasis role="bold">Example LE Implementation</emphasis>
 		</para>
               </entry>
               <entry align="center" valign="middle">
@@ -11454,6 +12059,11 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
    vctzlsbb  r,a
 		</programlisting>
               </entry>
+              <entry>
+		<programlisting>
+   vclzlsbb  r,a
+		</programlisting>
+              </entry>
               <entry align="center" valign="middle">
 		<para>ISA 3.0 or later</para>
 	      </entry>
@@ -11468,6 +12078,11 @@ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="VIPR.vec-ref">
               <entry>
 		<programlisting>
    vctzlsbb  r,a
+		</programlisting>
+              </entry>
+              <entry>
+		<programlisting>
+   vclzlsbb  r,a
 		</programlisting>
               </entry>
               <entry align="center" valign="middle">


### PR DESCRIPTION
Add examples for
- `vec_cntlz`, `vec_cnttz`
- `vec_cntlz_lsbb`, `vec_cnttz_lsbb`

Fixes #15.

* `vec_cntlz`:
  > ![Screenshot from 2020-05-12 06-37-07](https://user-images.githubusercontent.com/12301795/81683243-7e2b0d80-941b-11ea-8408-f375ccd8db3f.png)
  > ![Screenshot from 2020-05-12 06-37-28](https://user-images.githubusercontent.com/12301795/81683252-81be9480-941b-11ea-939d-610fc7a03b43.png)
* `vec_cnttz`:
   > ![Screenshot from 2020-05-12 06-37-58](https://user-images.githubusercontent.com/12301795/81683264-871bdf00-941b-11ea-8968-0c7cff6336a9.png)
   > ![Screenshot from 2020-05-12 06-38-19](https://user-images.githubusercontent.com/12301795/81683283-8be09300-941b-11ea-9232-4e5550f4c47c.png)
* `vec_cntlz_lsbb`:
  > ![Screenshot from 2020-05-12 06-38-39](https://user-images.githubusercontent.com/12301795/81683371-b6cae700-941b-11ea-8b24-bfa0db57bbd4.png)
  > ![Screenshot from 2020-05-12 06-38-54](https://user-images.githubusercontent.com/12301795/81683304-93a03780-941b-11ea-8914-88b931f0ced0.png)
* `vec_cnttz_lsbb`:
  > ![Screenshot from 2020-05-12 06-39-19](https://user-images.githubusercontent.com/12301795/81683401-bcc0c800-941b-11ea-9b58-1c753427f274.png)
  > ![Screenshot from 2020-05-12 06-39-33](https://user-images.githubusercontent.com/12301795/81683416-bfbbb880-941b-11ea-86d6-c58ce99ac18c.png)

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>